### PR TITLE
Enable continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,23 @@
 language: python
-python:
-  - "2.7"
+sudo: false
+cache: pip
+matrix:
+  include:
+    - python: "2.7"
+      os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
+      env:
+         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
 before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get install -y gcc-4.9-base
+  - eval "${MATRIX_EVAL}"
+
 install:
   - pip install -r requirements.txt
-  - CC=gcc-4.9 python setup.py build
+  - python setup.py build
+
 script: pytest test/metrics.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+  - "2.7"
+install:
+  - pip install -r requirements.txt
+  - python setup.py build
+script: pytest test/metrics.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,6 @@ before_install:
 
 install:
   - pip install -r requirements.txt
-  - CC=gcc-4.9 python setup.py build
+  - CC=gcc-4.9 python setup.py build install
 
 script: pytest test/metrics.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ install:
   - pip install -r requirements.txt
   - python setup.py build install
 
-script: pytest test/metrics.py
+script: "true"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 python:
   - "2.7"
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y gcc-4.9-base
 install:
   - pip install -r requirements.txt
   - python setup.py build

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,6 @@ before_install:
 
 install:
   - pip install -r requirements.txt
-  - CC=gcc-4.9 python setup.py build install
+  - python setup.py build install
 
 script: pytest test/metrics.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,6 @@ before_install:
 
 install:
   - pip install -r requirements.txt
-  - python setup.py build
+  - CC=gcc-4.9 python setup.py build
 
 script: pytest test/metrics.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-4.9
+            - g++-6
       env:
-         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+         - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
 before_install:
   - eval "${MATRIX_EVAL}"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,7 @@ matrix:
           packages:
             - g++-6
       env:
-         - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
-before_install:
-  - eval "${MATRIX_EVAL}"
-
+         - CC=gcc-6 CXX=g++-6
 install:
   - pip install -r requirements.txt
   - python setup.py build install

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ before_install:
   - sudo apt-get install -y gcc-4.9-base
 install:
   - pip install -r requirements.txt
-  - python setup.py build
+  - CC=gcc-4.9 python setup.py build
 script: pytest test/metrics.py


### PR DESCRIPTION
Addresses #15.

Follows [Travis CI's recommendations for building C++ 11 and beyond](https://docs.travis-ci.com/user/languages/cpp/#C11-C%2B%2B11-(and-Beyond)-and-Toolchain-Versioning).

Although the basic build steps succeed, The Travis CI job currently [fails](https://travis-ci.org/carlschroedl/python-mander#L815) with an import error while executing the tests. This is probably because I don't know how to get the tests to execute successfully. It is also possible that the tests are broken.

We could try some combination of:
* update the `script` section of the `.travis.yml` so that it correctly execute the tests
* fix the tests to resolve errors

Alternatively, in the short term we could change the `script` section to `true` so that Travis CI verifies that the basic build steps succeed without verifying that the tests run correctly.

Do y'all have any ideas on how to proceed?