### PR TITLE
add conda recipe and circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,39 @@
+version: 2
+jobs:
+  build:
+    docker:
+      # this docker image has compilers already cached and ready
+      - image: conda/c3i-linux-64
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # currently we have no external dependencies aside from two git submodules
+      # - restore_cache:
+      #     keys:
+      #     - v1-dependencies-{{ checksum "environment.yml" }}
+      #     - v1-dependencies-
+
+      - run:
+          name: build recipe
+          command: conda build conda.recipe
+
+      # currently we have no external dependencies aside from two git submodules
+      # - save_cache:
+      #     paths:
+      #       - /opt/conda
+      #     key: v1-dependencies-{{ checksum "environment.yml" }}
+
+      # tests are run as part of the build process
+      # - run:
+      #     name: run tests
+      #     command: |
+      #       source activate adj
+      #       pytest tests
+
+      # we could potentially be uploading our build artifacts here.  Maybe someday.
+      - store_artifacts:
+          path: test-reports
+          destination: test-reports

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,23 @@
+package:
+  name: python-mander
+  version: {{ GIT_DESCRIBE_TAG }}.{{ GIT_BUILD_STR }}
+
+source:
+  git_url: ../
+
+build:
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+  host:
+    - python
+    - setuptools
+  run:
+    - python
+
+test:
+  imports:
+    - mander

--- a/conda.recipe/run_test.py
+++ b/conda.recipe/run_test.py
@@ -1,0 +1,3 @@
+import mander
+mander.getListOfBoundedScores()
+mander.getListOfUnboundedScores()


### PR DESCRIPTION
fixes #15 
closes #16 

This is only testing python 3 at the moment.  It can be extended to do a matrix of python versions pretty readily.